### PR TITLE
fix(export): fixed issue where very small eport (compared to wanted zoom level) ends in core dump

### DIFF
--- a/src/exportImage.py
+++ b/src/exportImage.py
@@ -15,7 +15,7 @@ def get_zoom_resolution(zoom_to_resolution_dict, zoom_level):
         raise Exception(f'No such zoom level. got: {zoom_level}')
 
 
-def is_valid_zoom_for_area(resolution, tile_size, bbox):
+def is_valid_zoom_for_area(resolution, bbox):
     top_right_lat = bbox[3]
     top_right_lon = bbox[2]
     bottom_left_lat = bbox[1]
@@ -51,7 +51,7 @@ class ExportImage:
             try:
                 resolution = get_zoom_resolution(
                     self.__zoom_to_resolution, max_zoom)
-                if not is_valid_zoom_for_area(resolution, 256, bbox):
+                if not is_valid_zoom_for_area(resolution, bbox):
                     raise Exception(
                         'Invalid zoom level for exported area (exported area too small)')
                 self.__helper.create_folder_if_not_exists(

--- a/tests/exportImage.py
+++ b/tests/exportImage.py
@@ -1,0 +1,49 @@
+import unittest
+from src.exportImage import is_valid_zoom_for_area
+
+
+# Zoom level 15
+valid_export = {
+    "resolution": 2.14576721191406e-05,
+    "bbox": [-122.456598, 37.735764, -122.455048, 37.737011]
+}
+
+valid_negative_values = {
+    "resolution": 2.14576721191406e-05,
+    "bbox": [-122.456598, -37.737011, -122.455048, -37.735764]
+}
+
+# Zoom level 4
+invalid_export = {
+    "resolution": 0.0439453125,
+    "bbox": [
+        35.34901384644131,
+        33.0377182656489,
+        35.34915987312472,
+        33.037930668097495
+    ]
+}
+
+
+class TestExport(unittest.TestCase):
+    def test_valid_export(self):
+        resolution = valid_export["resolution"]
+        bbox = valid_export["bbox"]
+        result = is_valid_zoom_for_area(resolution, bbox)
+        self.assertEqual(result, True)
+
+    def test_valid_negative_export(self):
+        resolution = valid_negative_values["resolution"]
+        bbox = valid_negative_values["bbox"]
+        result = is_valid_zoom_for_area(resolution, bbox)
+        self.assertEqual(result, True)
+
+    def test_invalid_export(self):
+        resolution = invalid_export["resolution"]
+        bbox = invalid_export["bbox"]
+        result = is_valid_zoom_for_area(resolution, bbox)
+        self.assertEqual(result, False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Export would fail because it would be less than a pixle in the wanted resolution.
Now preventing this from happening by failing the export (throwing an error).